### PR TITLE
ensure that all discharge macaroons are used exactly once

### DIFF
--- a/macaroon.go
+++ b/macaroon.go
@@ -204,20 +204,30 @@ func bindForRequest(rootSig, dischargeSig []byte) []byte {
 //
 // The discharge macaroons should be provided in discharges.
 //
-// Verify returns true if the verification succeeds; if returns
-// (false, nil) if the verification fails, and (false, err) if
-// the verification cannot be asserted (but may not be false).
-//
-// TODO(rog) is there a possible DOS attack that can cause this
-// function to infinitely recurse?
+// Verify returns nil if the verification succeeds.
 func (m *Macaroon) Verify(rootKey []byte, check func(caveat string) error, discharges []*Macaroon) error {
 	// TODO(rog) consider distinguishing between classes of
 	// check error - some errors may be resolved by minting
 	// a new macaroon; others may not.
-	return m.verify(m.sig, rootKey, check, discharges)
+	used := make([]int, len(discharges))
+	if err := m.verify(m.sig, rootKey, check, discharges, used); err != nil {
+		return err
+	}
+	for i, dm := range discharges {
+		switch used[i] {
+		case 0:
+			return fmt.Errorf("discharge macaroon %q was not used", dm.Id())
+		case 1:
+			continue
+		default:
+			// Should be impossible because of check in verify, but be defensive.
+			return fmt.Errorf("discharge macaroon %q was used more than once", dm.Id())
+		}
+	}
+	return nil
 }
 
-func (m *Macaroon) verify(rootSig []byte, rootKey []byte, check func(caveat string) error, discharges []*Macaroon) error {
+func (m *Macaroon) verify(rootSig []byte, rootKey []byte, check func(caveat string) error, discharges []*Macaroon, used []int) error {
 	if len(rootSig) == 0 {
 		rootSig = m.sig
 	}
@@ -232,23 +242,25 @@ func (m *Macaroon) verify(rootSig []byte, rootKey []byte, check func(caveat stri
 			// possible discharge macaroon verifications
 			// if there's more than one discharge macaroon
 			// with the required id.
-			var verifyErr error
 			found := false
-			for _, dm := range discharges {
+			for di, dm := range discharges {
 				if !bytes.Equal(dm.dataBytes(dm.id), m.dataBytes(cav.caveatId)) {
 					continue
 				}
 				found = true
-				verifyErr = dm.verify(rootSig, cavKey, check, discharges)
-				if verifyErr == nil {
-					break
+
+				// It's important that we do this before calling verify,
+				// as it prevents potentially infinite recursion.
+				if used[di]++; used[di] > 1 {
+					return fmt.Errorf("discharge macaroon %q was used more than once", dm.Id())
 				}
+				if err := dm.verify(rootSig, cavKey, check, discharges, used); err != nil {
+					return err
+				}
+				break
 			}
 			if !found {
 				return fmt.Errorf("cannot find discharge macaroon for caveat %q", m.dataBytes(cav.caveatId))
-			}
-			if verifyErr != nil {
-				return verifyErr
 			}
 		} else {
 			if err := check(string(m.dataBytes(cav.caveatId))); err != nil {

--- a/macaroon_test.go
+++ b/macaroon_test.go
@@ -202,25 +202,82 @@ var verifyTests = []struct {
 		conditions: map[string]bool{
 			"wonderful": true,
 		},
-		expectErr: `condition "top of the world" not met`,
+		expectErr: `condition "splendid" not met`,
 	}, {
 		conditions: map[string]bool{
 			"wonderful":        true,
 			"splendid":         true,
 			"top of the world": true,
 		},
+		expectErr: `discharge macaroon "bob-is-great" was not used`,
 	}, {
 		conditions: map[string]bool{
 			"wonderful":        true,
 			"splendid":         false,
 			"top of the world": true,
 		},
+		expectErr: `condition "splendid" not met`,
 	}, {
 		conditions: map[string]bool{
 			"wonderful":        true,
 			"splendid":         true,
 			"top of the world": false,
 		},
+		expectErr: `discharge macaroon "bob-is-great" was not used`,
+	}},
+}, {
+	about: "one discharge used for two macaroons",
+	macaroons: []macaroonSpec{{
+		rootKey: "root-key",
+		id:      "root-id",
+		caveats: []caveat{{
+			condition: "somewhere else",
+			location:  "bob",
+			rootKey:   "bob-caveat-root-key",
+		}, {
+			condition: "bob-is-great",
+			location:  "charlie",
+			rootKey:   "bob-caveat-root-key",
+		}},
+	}, {
+		location: "bob",
+		rootKey:  "bob-caveat-root-key",
+		id:       "somewhere else",
+		caveats: []caveat{{
+			condition: "bob-is-great",
+			location:  "charlie",
+			rootKey:   "bob-caveat-root-key",
+		}},
+	}, {
+		location: "bob",
+		rootKey:  "bob-caveat-root-key",
+		id:       "bob-is-great",
+	}},
+	conditions: []conditionTest{{
+		expectErr: `discharge macaroon "bob-is-great" was used more than once`,
+	}},
+}, {
+	about: "recursive third party caveat",
+	macaroons: []macaroonSpec{{
+		rootKey: "root-key",
+		id:      "root-id",
+		caveats: []caveat{{
+			condition: "bob-is-great",
+			location:  "bob",
+			rootKey:   "bob-caveat-root-key",
+		}},
+	}, {
+		location: "bob",
+		rootKey:  "bob-caveat-root-key",
+		id:       "bob-is-great",
+		caveats: []caveat{{
+			condition: "bob-is-great",
+			location:  "charlie",
+			rootKey:   "bob-caveat-root-key",
+		}},
+	}},
+	conditions: []conditionTest{{
+		expectErr: `discharge macaroon "bob-is-great" was used more than once`,
 	}},
 }, {
 	about: "two third party caveats",
@@ -323,6 +380,18 @@ var verifyTests = []struct {
 			"spiffing":    true,
 		},
 		expectErr: `condition "high-fiving" not met`,
+	}},
+}, {
+	about: "unused discharge",
+	macaroons: []macaroonSpec{{
+		rootKey: "root-key",
+		id:      "root-id",
+	}, {
+		rootKey: "other-key",
+		id:      "unused",
+	}},
+	conditions: []conditionTest{{
+		expectErr: `discharge macaroon "unused" was not used`,
 	}},
 }}
 


### PR DESCRIPTION
This means means that if we get a successful discharge, we can be sure
that all the first party caveats presented in the macaroon slice have
been checked.
