### PR TITLE
bring binary serialization in line with libmacaroons

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -10,29 +10,46 @@ import (
 	"golang.org/x/crypto/nacl/secretbox"
 )
 
-func keyedHash(key, text []byte) []byte {
+func keyedHash(key *[hashLen]byte, text []byte) *[hashLen]byte {
 	h := keyedHasher(key)
 	h.Write([]byte(text))
-	return h.Sum(nil)
+	var sum [hashLen]byte
+	hashSum(h, &sum)
+	return &sum
 }
 
-func keyedHasher(key []byte) hash.Hash {
-	return hmac.New(sha256.New, key)
+func keyedHasher(key *[hashLen]byte) hash.Hash {
+	return hmac.New(sha256.New, key[:])
 }
 
-func makeKey(key []byte) *[keyLen]byte {
-	if len(key) < keyLen {
-		var h [keyLen]byte
-		copy(h[:], key)
-		return &h
+var keyGen = []byte("macaroons-key-generator")
+
+// makeKey derives a fixed length key from a variable
+// length key. The keyGen constant is the same
+// as that used in libmacaroons.
+func makeKey(variableKey []byte) *[keyLen]byte {
+	h := hmac.New(sha256.New, keyGen)
+	h.Write(variableKey)
+	var key [keyLen]byte
+	hashSum(h, &key)
+	return &key
+}
+
+// hashSum calls h.Sum to put the sum into
+// the given destination. It also sanity
+// checks that the result really is the expected
+// size.
+func hashSum(h hash.Hash, dest *[hashLen]byte) {
+	r := h.Sum(dest[:0])
+	if len(r) != len(dest) {
+		panic("hash size inconsistency")
 	}
-	h := sha256.Sum256(key)
-	return &h
 }
 
 const (
 	keyLen   = 32
 	nonceLen = 24
+	hashLen  = sha256.Size
 )
 
 func newNonce(r io.Reader) (*[nonceLen]byte, error) {
@@ -44,26 +61,31 @@ func newNonce(r io.Reader) (*[nonceLen]byte, error) {
 	return &nonce, nil
 }
 
-func encrypt(key, text []byte, r io.Reader) ([]byte, error) {
+func encrypt(key *[keyLen]byte, text *[hashLen]byte, r io.Reader) ([]byte, error) {
 	nonce, err := newNonce(r)
 	if err != nil {
 		return nil, err
 	}
 	out := make([]byte, 0, len(nonce)+secretbox.Overhead+len(text))
 	out = append(out, nonce[:]...)
-	return secretbox.Seal(out, text, nonce, makeKey(key)), nil
+	return secretbox.Seal(out, text[:], nonce, key), nil
 }
 
-func decrypt(key, ciphertext []byte) ([]byte, error) {
+func decrypt(key *[keyLen]byte, ciphertext []byte) (*[hashLen]byte, error) {
 	if len(ciphertext) < nonceLen+secretbox.Overhead {
 		return nil, fmt.Errorf("message too short")
 	}
 	var nonce [nonceLen]byte
 	copy(nonce[:], ciphertext)
 	ciphertext = ciphertext[nonceLen:]
-	text, ok := secretbox.Open(nil, ciphertext, &nonce, makeKey(key))
+	text, ok := secretbox.Open(nil, ciphertext, &nonce, key)
 	if !ok {
 		return nil, fmt.Errorf("decryption failure")
 	}
-	return text, nil
+	if len(text) != hashLen {
+		return nil, fmt.Errorf("decrypted text is wrong length")
+	}
+	var rtext [hashLen]byte
+	copy(rtext[:], text)
+	return &rtext, nil
 }

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -12,14 +12,15 @@ type cryptoSuite struct{}
 
 var _ = gc.Suite(&cryptoSuite{})
 
+var testCryptKey = &[hashLen]byte{'k', 'e', 'y'}
+var testCryptText = &[hashLen]byte{'t', 'e', 'x', 't'}
+
 func (*cryptoSuite) TestEncDec(c *gc.C) {
-	key := []byte("a key")
-	text := []byte("some text")
-	b, err := encrypt(key, text, rand.Reader)
+	b, err := encrypt(testCryptKey, testCryptText, rand.Reader)
 	c.Assert(err, gc.IsNil)
-	t, err := decrypt(key, b)
+	t, err := decrypt(testCryptKey, b)
 	c.Assert(err, gc.IsNil)
-	c.Assert(string(t), gc.Equals, string(text))
+	c.Assert(string(t[:]), gc.Equals, string(testCryptText[:]))
 }
 
 func (*cryptoSuite) TestUniqueNonces(c *gc.C) {
@@ -42,17 +43,17 @@ func (*cryptoSuite) TestBadRandom(c *gc.C) {
 	_, err := newNonce(&ErrorReader{})
 	c.Assert(err, gc.ErrorMatches, "^cannot generate random bytes:.*")
 
-	_, err = encrypt([]byte("a key"), []byte("some text"), &ErrorReader{})
+	_, err = encrypt(testCryptKey, testCryptText, &ErrorReader{})
 	c.Assert(err, gc.ErrorMatches, "^cannot generate random bytes:.*")
 }
 
 func (*cryptoSuite) TestBadCiphertext(c *gc.C) {
 	buf := randomBytes(nonceLen + secretbox.Overhead)
 	for i := range buf {
-		_, err := decrypt([]byte("a key"), buf[0:i])
+		_, err := decrypt(testCryptKey, buf[0:i])
 		c.Assert(err, gc.ErrorMatches, "message too short")
 	}
-	_, err := decrypt([]byte("a key"), buf)
+	_, err := decrypt(testCryptKey, buf)
 	c.Assert(err, gc.ErrorMatches, "decryption failure")
 }
 


### PR DESCRIPTION
Each field contains a trailing newline character.

Also change signature calculation to be in line
with libmacaroons.

Because libmacaroons uses the sha256 output directly
as the encryption key for third party caveat verification
ids, we change the representation of hashes to be
an array rather than a slice. This means that if the
relative sizes change at some point in the future (for
example if a different hash algorithm is used), the
compiler will tell us that there is a problem.
