### PR TITLE
fix tests to work with base64 encoding without pad characters

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -53,7 +53,7 @@ func (m *Macaroon) MarshalJSON() ([]byte, error) {
 		mjson.Caveats[i] = caveatJSON{
 			Location: m.dataStr(cav.location),
 			CID:      m.dataStr(cav.caveatId),
-			VID:      base64.URLEncoding.EncodeToString(m.dataBytes(cav.verificationId)),
+			VID:      base64.RawURLEncoding.EncodeToString(m.dataBytes(cav.verificationId)),
 		}
 	}
 	data, err := json.Marshal(mjson)
@@ -244,16 +244,8 @@ func (s *Slice) UnmarshalBinary(data []byte) error {
 // base64Decode decodes base64 data that might be missing trailing
 // pad characters.
 func base64Decode(b64String string) ([]byte, error) {
-	paddedLen := (len(b64String) + 3) / 4 * 4
-	b64data := make([]byte, len(b64String), paddedLen)
-	copy(b64data, b64String)
-	for i := len(b64String); i < paddedLen; i++ {
-		b64data = append(b64data, '=')
+	if data, err := base64.StdEncoding.DecodeString(b64String); err == nil {
+		return data, nil
 	}
-	data := make([]byte, base64.URLEncoding.DecodedLen(len(b64data)))
-	n, err := base64.URLEncoding.Decode(data, b64data)
-	if err != nil {
-		return nil, err
-	}
-	return data[0:n], nil
+	return base64.RawURLEncoding.DecodeString(b64String)
 }


### PR DESCRIPTION
It seems that we didn't fix them when we fixed the decoding
to allow encoding in the libmacaroons style.

Also simplify the implementation slightly, allow both
standard and URL encoding in caveat ids, and use
actual data from libmacaroons now that our signature
calculations are the same.
