### PR TITLE
fix binary unmarshaling

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -152,6 +152,7 @@ func (m *Macaroon) unmarshalBinaryNoCopy(data []byte) error {
 		case fieldCaveatId:
 			if cav.caveatId.len() != 0 {
 				m.caveats = append(m.caveats, cav)
+				cav = caveat{}
 			}
 			cav.caveatId = p
 		case fieldVerificationId:

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -14,7 +14,13 @@ func (*marshalSuite) TestMarshalUnmarshalMacaroon(c *gc.C) {
 	rootKey := []byte("secret")
 	m := MustNew(rootKey, "some id", "a location")
 
-	err := m.AddFirstPartyCaveat("a caveat")
+	// Adding the third party caveat before the first party caveat
+	// tests a former bug where the caveat wasn't zeroed
+	// before moving to the next caveat.
+	err := m.AddThirdPartyCaveat([]byte("shared root key"), "3rd party caveat", "remote.com")
+	c.Assert(err, gc.IsNil)
+
+	err = m.AddFirstPartyCaveat("a caveat")
 	c.Assert(err, gc.IsNil)
 
 	b, err := m.MarshalBinary()


### PR DESCRIPTION
We weren't zeroing the caveat each time,
so the third party verification id bled through
from one to the other.
