### PR TITLE
update API in preparation for format changes

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 )
 
 func randomBytes(n int) []byte {
@@ -19,7 +19,7 @@ func randomBytes(n int) []byte {
 
 func BenchmarkNew(b *testing.B) {
 	rootKey := randomBytes(24)
-	id := base64.StdEncoding.EncodeToString(randomBytes(100))
+	id := []byte(base64.StdEncoding.EncodeToString(randomBytes(100)))
 	loc := base64.StdEncoding.EncodeToString(randomBytes(40))
 	b.ResetTimer()
 	for i := b.N - 1; i >= 0; i-- {
@@ -29,7 +29,7 @@ func BenchmarkNew(b *testing.B) {
 
 func BenchmarkAddCaveat(b *testing.B) {
 	rootKey := randomBytes(24)
-	id := base64.StdEncoding.EncodeToString(randomBytes(100))
+	id := []byte(base64.StdEncoding.EncodeToString(randomBytes(100)))
 	loc := base64.StdEncoding.EncodeToString(randomBytes(40))
 	b.ResetTimer()
 	for i := b.N - 1; i >= 0; i-- {
@@ -70,7 +70,7 @@ func BenchmarkVerifySmall(b *testing.B) {
 
 func BenchmarkMarshalJSON(b *testing.B) {
 	rootKey := randomBytes(24)
-	id := base64.StdEncoding.EncodeToString(randomBytes(100))
+	id := []byte(base64.StdEncoding.EncodeToString(randomBytes(100)))
 	loc := base64.StdEncoding.EncodeToString(randomBytes(40))
 	m := MustNew(rootKey, id, loc)
 	b.ResetTimer()
@@ -82,7 +82,7 @@ func BenchmarkMarshalJSON(b *testing.B) {
 	}
 }
 
-func MustNew(rootKey []byte, id, loc string) *macaroon.Macaroon {
+func MustNew(rootKey, id []byte, loc string) *macaroon.Macaroon {
 	m, err := macaroon.New(rootKey, id, loc)
 	if err != nil {
 		panic(err)
@@ -92,7 +92,7 @@ func MustNew(rootKey []byte, id, loc string) *macaroon.Macaroon {
 
 func BenchmarkUnmarshalJSON(b *testing.B) {
 	rootKey := randomBytes(24)
-	id := base64.StdEncoding.EncodeToString(randomBytes(100))
+	id := []byte(base64.StdEncoding.EncodeToString(randomBytes(100)))
 	loc := base64.StdEncoding.EncodeToString(randomBytes(40))
 	m := MustNew(rootKey, id, loc)
 	data, err := m.MarshalJSON()

--- a/export_test.go
+++ b/export_test.go
@@ -1,10 +1,5 @@
 package macaroon
 
-// Data returns the macaroon's data.
-func (m *Macaroon) Data() []byte {
-	return m.data
-}
-
 // AddThirdPartyCaveatWithRand adds a third-party caveat to the macaroon, using
 // the given source of randomness for encrypting the caveat id.
 var AddThirdPartyCaveatWithRand = (*Macaroon).addThirdPartyCaveatWithRand

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -3,7 +3,7 @@ package macaroon_test
 import (
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 )
 
 type marshalSuite struct{}
@@ -12,12 +12,12 @@ var _ = gc.Suite(&marshalSuite{})
 
 func (*marshalSuite) TestMarshalUnmarshalMacaroon(c *gc.C) {
 	rootKey := []byte("secret")
-	m := MustNew(rootKey, "some id", "a location")
+	m := MustNew(rootKey, []byte("some id"), "a location")
 
 	// Adding the third party caveat before the first party caveat
 	// tests a former bug where the caveat wasn't zeroed
 	// before moving to the next caveat.
-	err := m.AddThirdPartyCaveat([]byte("shared root key"), "3rd party caveat", "remote.com")
+	err := m.AddThirdPartyCaveat([]byte("shared root key"), []byte("3rd party caveat"), "remote.com")
 	c.Assert(err, gc.IsNil)
 
 	err = m.AddFirstPartyCaveat("a caveat")
@@ -31,7 +31,7 @@ func (*marshalSuite) TestMarshalUnmarshalMacaroon(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(m.Location(), gc.Equals, unmarshaledM.Location())
-	c.Assert(m.Id(), gc.Equals, unmarshaledM.Id())
+	c.Assert(string(m.Id()), gc.Equals, string(unmarshaledM.Id()))
 	c.Assert(m.Signature(), gc.DeepEquals, unmarshaledM.Signature())
 	c.Assert(m.Caveats(), gc.DeepEquals, unmarshaledM.Caveats())
 	c.Assert(m, gc.DeepEquals, unmarshaledM)
@@ -39,8 +39,8 @@ func (*marshalSuite) TestMarshalUnmarshalMacaroon(c *gc.C) {
 
 func (*marshalSuite) TestMarshalUnmarshalSlice(c *gc.C) {
 	rootKey := []byte("secret")
-	m1 := MustNew(rootKey, "some id", "a location")
-	m2 := MustNew(rootKey, "some other id", "another location")
+	m1 := MustNew(rootKey, []byte("some id"), "a location")
+	m2 := MustNew(rootKey, []byte("some other id"), "another location")
 
 	err := m1.AddFirstPartyCaveat("a caveat")
 	c.Assert(err, gc.IsNil)
@@ -59,7 +59,7 @@ func (*marshalSuite) TestMarshalUnmarshalSlice(c *gc.C) {
 	c.Assert(unmarshaledMacs, gc.HasLen, len(macaroons))
 	for i, m := range macaroons {
 		c.Assert(m.Location(), gc.Equals, unmarshaledMacs[i].Location())
-		c.Assert(m.Id(), gc.Equals, unmarshaledMacs[i].Id())
+		c.Assert(string(m.Id()), gc.Equals, string(unmarshaledMacs[i].Id()))
 		c.Assert(m.Signature(), gc.DeepEquals, unmarshaledMacs[i].Signature())
 		c.Assert(m.Caveats(), gc.DeepEquals, unmarshaledMacs[i].Caveats())
 	}
@@ -78,8 +78,8 @@ func (*marshalSuite) TestMarshalUnmarshalSlice(c *gc.C) {
 
 func (*marshalSuite) TestSliceRoundtrip(c *gc.C) {
 	rootKey := []byte("secret")
-	m1 := MustNew(rootKey, "some id", "a location")
-	m2 := MustNew(rootKey, "some other id", "another location")
+	m1 := MustNew(rootKey, []byte("some id"), "a location")
+	m2 := MustNew(rootKey, []byte("some other id"), "another location")
 
 	err := m1.AddFirstPartyCaveat("a caveat")
 	c.Assert(err, gc.IsNil)


### PR DESCRIPTION
This changes the internal representation so that
we don't use the binary encoding directly.

We also change the API so that third party caveat
ids and the macaroon id itself are []byte not string,
and relax the length constraints which will only
apply when marshaling to the old binary format.

This breaks the API, so we make a new API version (v2-unstable);
we will probably change it further in subsequent PRs.

Benchmark changes:

```
benchmark                    old ns/op     new ns/op     delta
BenchmarkNew-4               9843          7429          -24.53%
BenchmarkAddCaveat-4         5581          5488          -1.67%
BenchmarkVerifyLarge-4       139496        140105        +0.44%
BenchmarkVerifySmall-4       9284          9366          +0.88%
BenchmarkMarshalJSON-4       4326          4578          +5.83%
BenchmarkUnmarshalJSON-4     9228          8675          -5.99%
```
