### PR TITLE
add packet parsing for v2 binary format

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -2,5 +2,5 @@ package macaroon
 
 var (
 	AddThirdPartyCaveatWithRand = (*Macaroon).addThirdPartyCaveatWithRand
-	MaxPacketV1Len = maxPacketV1Len
+	MaxPacketV1Len              = maxPacketV1Len
 )

--- a/packet-v2.go
+++ b/packet-v2.go
@@ -1,0 +1,98 @@
+package macaroon
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+type fieldType int
+
+// Field constants as used in the binary encoding.
+const (
+	fieldEOS            fieldType = 0
+	fieldLocation       fieldType = 1
+	fieldIdentifier     fieldType = 2
+	fieldVerificationId fieldType = 4
+	fieldSignature      fieldType = 6
+)
+
+type packetV2 struct {
+	// fieldType holds the type of the field.
+	fieldType fieldType
+
+	// data holds the packet's data.
+	data []byte
+}
+
+// parseSectionV2 parses a sequence of packets
+// in data. The sequence is terminated by a packet
+// with a field type of fieldEOS.
+func parseSectionV2(data []byte) ([]byte, []packetV2, error) {
+	prevFieldType := fieldType(-1)
+	var packets []packetV2
+	for {
+		if len(data) == 0 {
+			return nil, nil, fmt.Errorf("section extends past end of buffer")
+		}
+		rest, p, err := parsePacketV2(data)
+		if err != nil {
+			return nil, nil, err
+		}
+		if p.fieldType == fieldEOS {
+			return rest, packets, nil
+		}
+		if p.fieldType <= prevFieldType {
+			return nil, nil, fmt.Errorf("fields out of order")
+		}
+		packets = append(packets, p)
+		prevFieldType = p.fieldType
+		data = rest
+	}
+}
+
+// parsePacketV2 parses a V2 data package at the start
+// of the given data.
+// The format of a packet is as follows:
+//
+//	fieldType(varint) payloadLen(varint) data[payloadLen bytes]
+//
+// apart from fieldEOS which has no payloadLen or data (it's
+// a single zero byte).
+func parsePacketV2(data []byte) ([]byte, packetV2, error) {
+	data, ft, err := parseVarint(data)
+	if err != nil {
+		return nil, packetV2{}, err
+	}
+	p := packetV2{
+		fieldType: fieldType(ft),
+	}
+	if p.fieldType == fieldEOS {
+		return data, p, nil
+	}
+	data, payloadLen, err := parseVarint(data)
+	if err != nil {
+		return nil, packetV2{}, err
+	}
+	if payloadLen > len(data) {
+		return nil, packetV2{}, fmt.Errorf("field data extends past end of buffer")
+	}
+	p.data = data[0:payloadLen]
+	return data[payloadLen:], p, nil
+}
+
+// parseVarint parses the variable-length integer
+// at the start of the given data and returns rest
+// of the buffer and the number.
+func parseVarint(data []byte) ([]byte, int, error) {
+	val, n := binary.Uvarint(data)
+	if n > 0 {
+		if val > 0x7fffffff {
+			return nil, 0, fmt.Errorf("varint value out of range")
+		}
+		return data[n:], int(val), nil
+	}
+	if n == 0 {
+		return nil, 0, fmt.Errorf("varint value extends past end of buffer")
+	}
+	return nil, 0, fmt.Errorf("varint value out of range")
+}

--- a/packet-v2_test.go
+++ b/packet-v2_test.go
@@ -1,0 +1,126 @@
+package macaroon
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type packetV2Suite struct{}
+
+var _ = gc.Suite(&packetV2Suite{})
+
+var parsePacketV2Tests = []struct {
+	about        string
+	data         string
+	expectPacket packetV2
+	expectData   string
+	expectError  string
+}{{
+	about: "EOS packet",
+	data:  "\x00",
+	expectPacket: packetV2{
+		fieldType: fieldEOS,
+	},
+}, {
+	about: "simple field",
+	data:  "\x02\x03xyz",
+	expectPacket: packetV2{
+		fieldType: 2,
+		data:      []byte("xyz"),
+	},
+}, {
+	about:       "empty buffer",
+	data:        "",
+	expectError: "varint value extends past end of buffer",
+}, {
+	about:       "varint out of range",
+	data:        "\xff\xff\xff\xff\xff\xff\x7f",
+	expectError: "varint value out of range",
+}, {
+	about:       "varint way out of range",
+	data:        "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x7f",
+	expectError: "varint value out of range",
+}, {
+	about:       "unterminated varint",
+	data:        "\x80",
+	expectError: "varint value extends past end of buffer",
+}, {
+	about:       "field data too long",
+	data:        "\x01\x02a",
+	expectError: "field data extends past end of buffer",
+}, {
+	about:       "bad data length varint",
+	data:        "\x01\xff",
+	expectError: "varint value extends past end of buffer",
+}}
+
+func (*packetV2Suite) TestParsePacketV2(c *gc.C) {
+	for i, test := range parsePacketV2Tests {
+		c.Logf("test %d: %v", i, test.about)
+		data, p, err := parsePacketV2([]byte(test.data))
+		if test.expectError != "" {
+			c.Assert(err, gc.ErrorMatches, test.expectError)
+			c.Assert(data, gc.IsNil)
+			c.Assert(p, gc.DeepEquals, packetV2{})
+		} else {
+			c.Assert(err, gc.IsNil)
+			c.Assert(p, jc.DeepEquals, test.expectPacket)
+		}
+	}
+}
+
+var parseSectionV2Tests = []struct {
+	about string
+	data  string
+
+	expectData    string
+	expectPackets []packetV2
+	expectError   string
+}{{
+	about: "no packets",
+	data:  "\x00",
+}, {
+	about: "one packet",
+	data:  "\x02\x03xyz\x00",
+	expectPackets: []packetV2{{
+		fieldType: 2,
+		data:      []byte("xyz"),
+	}},
+}, {
+	about: "two packets",
+	data:  "\x02\x03xyz\x07\x05abcde\x00",
+	expectPackets: []packetV2{{
+		fieldType: 2,
+		data:      []byte("xyz"),
+	}, {
+		fieldType: 7,
+		data:      []byte("abcde"),
+	}},
+}, {
+	about:       "unterminated section",
+	data:        "\x02\x03xyz\x07\x05abcde",
+	expectError: "section extends past end of buffer",
+}, {
+	about:       "out of order fields",
+	data:        "\x07\x05abcde\x02\x03xyz\x00",
+	expectError: "fields out of order",
+}, {
+	about:       "bad packet",
+	data:        "\x07\x05abcde\xff",
+	expectError: "varint value extends past end of buffer",
+}}
+
+func (*packetV2Suite) TestParseSectionV2(c *gc.C) {
+	for i, test := range parseSectionV2Tests {
+		c.Logf("test %d: %v", i, test.about)
+		data, ps, err := parseSectionV2([]byte(test.data))
+		if test.expectError != "" {
+			c.Assert(err, gc.ErrorMatches, test.expectError)
+			c.Assert(data, gc.IsNil)
+			c.Assert(ps, gc.IsNil)
+		} else {
+			c.Assert(err, gc.IsNil)
+			c.Assert(ps, jc.DeepEquals, test.expectPackets)
+		}
+	}
+}


### PR DESCRIPTION
This adds low level functions for parsing the binary
format defined in https://github.com/rescrv/libmacaroons/blob/master/doc/format.txt
