### PR TITLE
fix possible panic when decoding V1-format macaroon

### DIFF
--- a/marshal-v1.go
+++ b/marshal-v1.go
@@ -75,7 +75,7 @@ func (m *Macaroon) initJSONV1(mjson *macaroonJSONV1) error {
 }
 
 // The original (v1) binary format of a macaroon is as follows.
-// Each identifier repesents a v1 packet.
+// Each identifier represents a v1 packet.
 //
 // location
 // identifier

--- a/packet-v1.go
+++ b/packet-v1.go
@@ -58,6 +58,9 @@ func parsePacketV1(data []byte) (packetV1, error) {
 	if plen > len(data) {
 		return packetV1{}, fmt.Errorf("packet size too big")
 	}
+	if plen < 4 {
+		return packetV1{}, fmt.Errorf("packet size too small")
+	}
 	data = data[4:plen]
 	i := bytes.IndexByte(data, ' ')
 	if i <= 0 {

--- a/packet-v1_test.go
+++ b/packet-v1_test.go
@@ -45,6 +45,9 @@ var parsePacketV1Tests = []struct {
 	data:      "0015field some data\n",
 	expectErr: "packet size too big",
 }, {
+	data:      "0003a\n",
+	expectErr: "packet size too small",
+}, {
 	data:      "0014fieldwithoutanyspaceordata\n",
 	expectErr: "cannot parse field name",
 }, {


### PR DESCRIPTION
This was found by the go-fuzz tool.
