### PR TITLE
associate macaroons with a version

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -23,7 +23,7 @@ func BenchmarkNew(b *testing.B) {
 	loc := base64.StdEncoding.EncodeToString(randomBytes(40))
 	b.ResetTimer()
 	for i := b.N - 1; i >= 0; i-- {
-		MustNew(rootKey, id, loc)
+		MustNew(rootKey, id, loc, macaroon.LatestVersion)
 	}
 }
 
@@ -34,7 +34,7 @@ func BenchmarkAddCaveat(b *testing.B) {
 	b.ResetTimer()
 	for i := b.N - 1; i >= 0; i-- {
 		b.StopTimer()
-		m := MustNew(rootKey, id, loc)
+		m := MustNew(rootKey, id, loc, macaroon.LatestVersion)
 		b.StartTimer()
 		m.AddFirstPartyCaveat("some caveat stuff")
 	}
@@ -72,7 +72,7 @@ func BenchmarkMarshalJSON(b *testing.B) {
 	rootKey := randomBytes(24)
 	id := []byte(base64.StdEncoding.EncodeToString(randomBytes(100)))
 	loc := base64.StdEncoding.EncodeToString(randomBytes(40))
-	m := MustNew(rootKey, id, loc)
+	m := MustNew(rootKey, id, loc, macaroon.LatestVersion)
 	b.ResetTimer()
 	for i := b.N - 1; i >= 0; i-- {
 		_, err := m.MarshalJSON()
@@ -82,8 +82,8 @@ func BenchmarkMarshalJSON(b *testing.B) {
 	}
 }
 
-func MustNew(rootKey, id []byte, loc string) *macaroon.Macaroon {
-	m, err := macaroon.New(rootKey, id, loc)
+func MustNew(rootKey, id []byte, loc string, vers macaroon.Version) *macaroon.Macaroon {
+	m, err := macaroon.New(rootKey, id, loc, vers)
 	if err != nil {
 		panic(err)
 	}
@@ -94,7 +94,7 @@ func BenchmarkUnmarshalJSON(b *testing.B) {
 	rootKey := randomBytes(24)
 	id := []byte(base64.StdEncoding.EncodeToString(randomBytes(100)))
 	loc := base64.StdEncoding.EncodeToString(randomBytes(40))
-	m := MustNew(rootKey, id, loc)
+	m := MustNew(rootKey, id, loc, macaroon.LatestVersion)
 	data, err := m.MarshalJSON()
 	if err != nil {
 		b.Fatalf("cannot marshal JSON: %v", err)

--- a/export_test.go
+++ b/export_test.go
@@ -5,9 +5,9 @@ var (
 	MaxPacketV1Len              = maxPacketV1Len
 )
 
-// SetUnmarshaledAs sets the unmarshaledAs field of m to o;
+// SetVersion sets the version field of m to v;
 // usually so that we can compare it for deep equality with
 // another differently unmarshaled macaroon.
-func (m *Macaroon) SetUnmarshaledAs(o MarshalOpts) {
-	m.unmarshaledAs = o
+func (m *Macaroon) SetVersion(v Version) {
+	m.version = v
 }

--- a/marshal-v1.go
+++ b/marshal-v1.go
@@ -54,7 +54,7 @@ func (m *Macaroon) marshalJSONV1() ([]byte, error) {
 // initJSONV1 initializes m from the JSON-unmarshaled data
 // held in mjson.
 func (m *Macaroon) initJSONV1(mjson *macaroonJSONV1) error {
-	m.init([]byte(mjson.Identifier), mjson.Location)
+	m.init([]byte(mjson.Identifier), mjson.Location, V1)
 	sig, err := hex.DecodeString(mjson.Signature)
 	if err != nil {
 		return fmt.Errorf("cannot decode macaroon signature %q: %v", m.sig, err)
@@ -102,7 +102,7 @@ func (m *Macaroon) parseBinaryV1(data []byte) ([]byte, error) {
 		return nil, err
 	}
 	data = data[id.totalLen:]
-	m.init(id.data, string(loc.data))
+	m.init(id.data, string(loc.data), V1)
 	var cav Caveat
 	for {
 		p, err := parsePacketV1(data)

--- a/marshal-v2.go
+++ b/marshal-v2.go
@@ -60,7 +60,7 @@ func (m *Macaroon) initJSONV2(mjson *macaroonJSONV2) error {
 	if err != nil {
 		return fmt.Errorf("invalid identifier: %v", err)
 	}
-	m.init(id, mjson.Location)
+	m.init(id, mjson.Location, V2)
 	sig, err := jsonBinaryField(mjson.Signature, mjson.SignatureHex, mjson.Signature64)
 	if err != nil {
 		return fmt.Errorf("invalid signature: %v", err)
@@ -134,7 +134,7 @@ func jsonBinaryField(s, shex, sb64 string) ([]byte, error) {
 //
 // See also https://github.com/rescrv/libmacaroons/blob/master/doc/format.txt
 
-// parseBinaryV1 parses the given data in V1 format into the macaroon. The macaroon's
+// parseBinaryV2 parses the given data in V2 format into the macaroon. The macaroon's
 // internal data structures will retain references to the data. It
 // returns the data after the end of the macaroon.
 func (m *Macaroon) parseBinaryV2(data []byte) ([]byte, error) {
@@ -155,7 +155,7 @@ func (m *Macaroon) parseBinaryV2(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("invalid macaroon header")
 	}
 	id := section[0].data
-	m.init(id, loc)
+	m.init(id, loc, V2)
 	for {
 		rest, section, err := parseSectionV2(data)
 		if err != nil {
@@ -203,7 +203,6 @@ func (m *Macaroon) parseBinaryV2(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("signature has unexpected length")
 	}
 	copy(m.sig[:], sig.data)
-	m.unmarshaledAs = MarshalV2
 	return data, nil
 }
 


### PR DESCRIPTION
One parsed as a given version, a macaroon will also
marshal as that version. We lose the MarshalAs method
and we also lose the option to marshal JSON macaroons
as a base64-encoded binary blob, which means that
there is no longer any need to specify how a macaroon
will be marshaled.

This means that we can now know whether a given caveat id
or macaroon id is appropriate for the version of the macaroon
and return an error if not.

It means that external code can also decide on what encoding
might be appropriate based on the macaroon version,
and it also simplifies the API.
