### PR TITLE
Use byte slice for caveat IDs

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -36,7 +36,7 @@ func BenchmarkAddCaveat(b *testing.B) {
 		b.StopTimer()
 		m := MustNew(rootKey, id, loc, macaroon.LatestVersion)
 		b.StartTimer()
-		m.AddFirstPartyCaveat("some caveat stuff")
+		m.AddFirstPartyCaveat([]byte("some caveat stuff"))
 	}
 }
 

--- a/macaroon.go
+++ b/macaroon.go
@@ -159,12 +159,8 @@ func (m *Macaroon) Bind(sig []byte) {
 // AddFirstPartyCaveat adds a caveat that will be verified
 // by the target service. The caveat id must be a UTF-8 encoded
 // string.
-func (m *Macaroon) AddFirstPartyCaveat(condition string) error {
-	if !utf8.ValidString(condition) {
-		return fmt.Errorf("first party caveat condition is not a valid utf-8 string")
-	}
-	m.addCaveat([]byte(condition), nil, "")
-	return nil
+func (m *Macaroon) AddFirstPartyCaveat(id []byte) error {
+	return m.addCaveat(id, nil, "")
 }
 
 // AddThirdPartyCaveat adds a third-party caveat to the macaroon,
@@ -185,8 +181,7 @@ func (m *Macaroon) addThirdPartyCaveatWithRand(rootKey, caveatId []byte, loc str
 	if err != nil {
 		return err
 	}
-	m.addCaveat(caveatId, verificationId, loc)
-	return nil
+	return m.addCaveat(caveatId, verificationId, loc)
 }
 
 var zeroKey [hashLen]byte

--- a/macaroon_test.go
+++ b/macaroon_test.go
@@ -46,7 +46,7 @@ func (*macaroonSuite) TestFirstPartyCaveat(c *gc.C) {
 	tested := make(map[string]bool)
 
 	for cav := range caveats {
-		m.AddFirstPartyCaveat(cav)
+		m.AddFirstPartyCaveat([]byte(cav))
 	}
 	expectErr := fmt.Errorf("condition not met")
 	check := func(cav string) error {
@@ -61,7 +61,7 @@ func (*macaroonSuite) TestFirstPartyCaveat(c *gc.C) {
 
 	c.Assert(tested, gc.DeepEquals, caveats)
 
-	m.AddFirstPartyCaveat("not met")
+	m.AddFirstPartyCaveat([]byte("not met"))
 	err = m.Verify(rootKey, check, nil)
 	c.Assert(err, gc.Equals, expectErr)
 
@@ -504,7 +504,7 @@ func (s *macaroonSuite) TestMarshalJSON(c *gc.C) {
 func (*macaroonSuite) testMarshalJSONWithVersion(c *gc.C, vers macaroon.Version) {
 	rootKey := []byte("secret")
 	m0 := MustNew(rootKey, []byte("some id"), "a location", vers)
-	m0.AddFirstPartyCaveat("account = 3735928559")
+	m0.AddFirstPartyCaveat([]byte("account = 3735928559"))
 	m0JSON, err := json.Marshal(m0)
 	c.Assert(err, gc.IsNil)
 	var m1 macaroon.Macaroon
@@ -732,7 +732,7 @@ func makeMacaroon(mspec macaroonSpec) *macaroon.Macaroon {
 				panic(err)
 			}
 		} else {
-			m.AddFirstPartyCaveat(cav.condition)
+			m.AddFirstPartyCaveat([]byte(cav.condition))
 		}
 	}
 	return m
@@ -755,9 +755,9 @@ func (*macaroonSuite) TestBinaryRoundTrip(c *gc.C) {
 	// first and third party caveats.
 	rootKey := []byte("secret")
 	m0 := MustNew(rootKey, []byte("some id"), "a location", macaroon.LatestVersion)
-	err := m0.AddFirstPartyCaveat("first caveat")
+	err := m0.AddFirstPartyCaveat([]byte("first caveat"))
 	c.Assert(err, gc.IsNil)
-	err = m0.AddFirstPartyCaveat("second caveat")
+	err = m0.AddFirstPartyCaveat([]byte("second caveat"))
 	c.Assert(err, gc.IsNil)
 	err = m0.AddThirdPartyCaveat([]byte("shared root key"), []byte("3rd party caveat"), "remote.com")
 	c.Assert(err, gc.IsNil)
@@ -784,11 +784,11 @@ func (*macaroonSuite) TestBinaryMarshalingAgainstLibmacaroon(c *gc.C) {
 	assertEqualMacaroons(c, &m0, &m1)
 }
 
-func (*macaroonSuite) TestInvalidMacaroonFields(c *gc.C) {
+func (*macaroonSuite) TestInvalidV1MacaroonFields(c *gc.C) {
 	rootKey := []byte("secret")
 	badString := "foo\xff"
 
-	m0 := MustNew(rootKey, []byte("some id"), "a location", macaroon.LatestVersion)
-	err := m0.AddFirstPartyCaveat(badString)
-	c.Assert(err, gc.ErrorMatches, `first party caveat condition is not a valid utf-8 string`)
+	m0 := MustNew(rootKey, []byte("some id"), "a location", macaroon.V1)
+	err := m0.AddFirstPartyCaveat([]byte(badString))
+	c.Assert(err, gc.ErrorMatches, "invalid caveat id for v1 macaroon")
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -29,7 +29,7 @@ func (*marshalSuite) testMarshalUnmarshalWithVersion(c *gc.C, vers macaroon.Vers
 	err := m.AddThirdPartyCaveat([]byte("shared root key"), []byte("3rd party caveat"), "remote.com")
 	c.Assert(err, gc.IsNil)
 
-	err = m.AddFirstPartyCaveat("a caveat")
+	err = m.AddFirstPartyCaveat([]byte("a caveat"))
 	c.Assert(err, gc.IsNil)
 
 	b, err := m.MarshalBinary()
@@ -88,9 +88,9 @@ func (*marshalSuite) testMarshalUnmarshalSliceWithVersion(c *gc.C, vers macaroon
 	m1 := MustNew(rootKey, []byte("some id"), "a location", vers)
 	m2 := MustNew(rootKey, []byte("some other id"), "another location", vers)
 
-	err := m1.AddFirstPartyCaveat("a caveat")
+	err := m1.AddFirstPartyCaveat([]byte("a caveat"))
 	c.Assert(err, gc.IsNil)
-	err = m2.AddFirstPartyCaveat("another caveat")
+	err = m2.AddFirstPartyCaveat([]byte("another caveat"))
 	c.Assert(err, gc.IsNil)
 
 	macaroons := macaroon.Slice{m1, m2}
@@ -117,7 +117,7 @@ func (*marshalSuite) testMarshalUnmarshalSliceWithVersion(c *gc.C, vers macaroon
 	// Check that appending a caveat to the first does not
 	// affect the second.
 	for i := 0; i < 10; i++ {
-		err = unmarshaledMacs[0].AddFirstPartyCaveat("caveat")
+		err = unmarshaledMacs[0].AddFirstPartyCaveat([]byte("caveat"))
 		c.Assert(err, gc.IsNil)
 	}
 	unmarshaledMacs[1].SetVersion(macaroons[1].Version())
@@ -138,9 +138,9 @@ func (*marshalSuite) testSliceRoundTripWithVersion(c *gc.C, vers macaroon.Versio
 	m1 := MustNew(rootKey, []byte("some id"), "a location", vers)
 	m2 := MustNew(rootKey, []byte("some other id"), "another location", vers)
 
-	err := m1.AddFirstPartyCaveat("a caveat")
+	err := m1.AddFirstPartyCaveat([]byte("a caveat"))
 	c.Assert(err, gc.IsNil)
-	err = m2.AddFirstPartyCaveat("another caveat")
+	err = m2.AddFirstPartyCaveat([]byte("another caveat"))
 	c.Assert(err, gc.IsNil)
 
 	macaroons := macaroon.Slice{m1, m2}


### PR DESCRIPTION
Using a byte slice is consistent with the macaroon ID, and allows adding caveats that have been encoded into byte slices without an extra round-trip through a string.

This also removes the valid UTF-8 requirement for V2 macaroons, which use a binary-safe encoding.

Closes #16
