### PR TITLE
export Base64Decode function

### DIFF
--- a/marshal-v1.go
+++ b/marshal-v1.go
@@ -65,7 +65,7 @@ func (m *Macaroon) initJSONV1(mjson *macaroonJSONV1) error {
 	copy(m.sig[:], sig)
 	m.caveats = m.caveats[:0]
 	for _, cav := range mjson.Caveats {
-		vid, err := base64Decode([]byte(cav.VID))
+		vid, err := Base64Decode([]byte(cav.VID))
 		if err != nil {
 			return fmt.Errorf("cannot decode verification id %q: %v", cav.VID, err)
 		}

--- a/marshal-v2.go
+++ b/marshal-v2.go
@@ -110,7 +110,7 @@ func jsonBinaryField(s, shex, sb64 string) ([]byte, error) {
 		}
 		return hex.DecodeString(shex)
 	case sb64 != "":
-		return base64Decode([]byte(sb64))
+		return Base64Decode([]byte(sb64))
 	}
 	return []byte{}, nil
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -157,3 +157,47 @@ func (*marshalSuite) testSliceRoundTripWithVersion(c *gc.C, vers macaroon.Versio
 
 	c.Assert(b, jc.DeepEquals, marshaledMacs)
 }
+
+var base64DecodeTests = []struct {
+	about       string
+	input       string
+	expect      string
+	expectError string
+}{{
+	about:  "empty string",
+	input:  "",
+	expect: "",
+}, {
+	about:  "standard encoding, padded",
+	input:  "Z29+IQ==",
+	expect: "go~!",
+}, {
+	about:  "URL encoding, padded",
+	input:  "Z29-IQ==",
+	expect: "go~!",
+}, {
+	about:  "standard encoding, not padded",
+	input:  "Z29+IQ",
+	expect: "go~!",
+}, {
+	about:  "URL encoding, not padded",
+	input:  "Z29-IQ",
+	expect: "go~!",
+}, {
+	about:       "standard encoding, too much padding",
+	input:       "Z29+IQ===",
+	expectError: `illegal base64 data at input byte 8`,
+}}
+
+func (*marshalSuite) TestBase64Decode(c *gc.C) {
+	for i, test := range base64DecodeTests {
+		c.Logf("test %d: %s", i, test.about)
+		out, err := macaroon.Base64Decode([]byte(test.input))
+		if test.expectError != "" {
+			c.Assert(err, gc.ErrorMatches, test.expectError)
+		} else {
+			c.Assert(err, gc.Equals, nil)
+			c.Assert(string(out), gc.Equals, test.expect)
+		}
+	}
+}


### PR DESCRIPTION
It doesn't seem large enough to merit its own package, and it's useful
to have the lax base64 decoding functionality in other macaroon-related
packages.

We also expand the range of encoding possibilities, because having
just padded-standard and unpadded-URL seems somewhat too arbitrary.
