### PR TITLE
Enforce "gopkg.in/macaroon.v1" canonical import

### DIFF
--- a/macaroon.go
+++ b/macaroon.go
@@ -5,7 +5,7 @@
 //
 // See the macaroon bakery packages at http://godoc.org/gopkg.in/macaroon-bakery.v0
 // for higher level services and operations that use macaroons.
-package macaroon
+package macaroon // import "gopkg.in/macaroon.v1"
 
 import (
 	"bytes"


### PR DESCRIPTION
I noticed some of my colleagues just import this code after finding https://github.com/go-macaroon/macaroon, causing duplications in the GOPATH, when other libraries instead use the correct import path (as documented in your README).

Go has a way to deal with that, see https://golang.org/cmd/go/#hdr-Import_path_checking

