### PR TITLE
add tracing functionality

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -55,7 +55,7 @@ func benchmarkVerify(b *testing.B, mspecs []macaroonSpec) {
 }
 
 func BenchmarkVerifyLarge(b *testing.B) {
-	benchmarkVerify(b, recursiveThirdPartyCaveatMacaroons)
+	benchmarkVerify(b, multilevelThirdPartyCaveatMacaroons)
 }
 
 func BenchmarkVerifySmall(b *testing.B) {

--- a/export_test.go
+++ b/export_test.go
@@ -2,8 +2,9 @@ package macaroon
 
 var (
 	AddThirdPartyCaveatWithRand = (*Macaroon).addThirdPartyCaveatWithRand
-	MaxPacketV1Len              = maxPacketV1Len
 )
+
+type MacaroonJSONV2 macaroonJSONV2
 
 // SetVersion sets the version field of m to v;
 // usually so that we can compare it for deep equality with

--- a/macaroon_test.go
+++ b/macaroon_test.go
@@ -363,8 +363,8 @@ var verifyTests = []struct {
 		expectErr: fmt.Sprintf(`cannot find discharge macaroon for caveat %x`, "barbara-is-great"),
 	}},
 }, {
-	about:     "recursive third party caveats",
-	macaroons: recursiveThirdPartyCaveatMacaroons,
+	about:     "multilevel third party caveats",
+	macaroons: multilevelThirdPartyCaveatMacaroons,
 	conditions: []conditionTest{{
 		conditions: map[string]bool{
 			"wonderful":   true,
@@ -395,7 +395,7 @@ var verifyTests = []struct {
 	}},
 }}
 
-var recursiveThirdPartyCaveatMacaroons = []macaroonSpec{{
+var multilevelThirdPartyCaveatMacaroons = []macaroonSpec{{
 	rootKey: "root-key",
 	id:      "root-id",
 	caveats: []caveat{{
@@ -483,6 +483,67 @@ func (*macaroonSuite) TestVerify(c *gc.C) {
 			c.Assert(cloneErr, gc.DeepEquals, err)
 		}
 	}
+}
+
+func (*macaroonSuite) TestTraceVerify(c *gc.C) {
+	rootKey, macaroons := makeMacaroons(multilevelThirdPartyCaveatMacaroons)
+	traces, err := macaroons[0].TraceVerify(rootKey, macaroons[1:])
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(traces, gc.HasLen, len(macaroons))
+	// Check that we can run through the resulting operations and
+	// arrive at the same signature.
+	for i, m := range macaroons {
+		r := traces[i].Results()
+		c.Assert(b64str(r[len(r)-1]), gc.Equals, b64str(m.Signature()), gc.Commentf("macaroon %d", i))
+	}
+}
+
+func (*macaroonSuite) TestTraceVerifyFailure(c *gc.C) {
+	rootKey, macaroons := makeMacaroons([]macaroonSpec{{
+		rootKey: "xxx",
+		id:      "hello",
+		caveats: []caveat{{
+			condition: "cond1",
+		}, {
+			condition: "cond2",
+		}, {
+			condition: "cond3",
+		}},
+	}})
+	// Marshal the macaroon, corrupt a condition, then unmarshal
+	// it and check we see the expected trace failure.
+	data, err := json.Marshal(macaroons[0])
+	c.Assert(err, gc.Equals, nil)
+	var jm macaroon.MacaroonJSONV2
+	err = json.Unmarshal(data, &jm)
+	c.Assert(err, gc.Equals, nil)
+	jm.Caveats[1].CID = "cond2 corrupted"
+	data, err = json.Marshal(jm)
+	c.Assert(err, gc.Equals, nil)
+
+	var corruptm *macaroon.Macaroon
+	err = json.Unmarshal(data, &corruptm)
+	c.Assert(err, gc.Equals, nil)
+
+	traces, err := corruptm.TraceVerify(rootKey, nil)
+	c.Assert(err, gc.ErrorMatches, `signature mismatch after caveat verification`)
+	c.Assert(traces, gc.HasLen, 1)
+	var kinds []macaroon.TraceOpKind
+	for _, op := range traces[0].Ops {
+		kinds = append(kinds, op.Kind)
+	}
+	c.Assert(kinds, gc.DeepEquals, []macaroon.TraceOpKind{
+		macaroon.TraceMakeKey,
+		macaroon.TraceHash, // id
+		macaroon.TraceHash, // cond1
+		macaroon.TraceHash, // cond2
+		macaroon.TraceHash, // cond3
+		macaroon.TraceFail, // sig mismatch
+	})
+}
+
+func b64str(b []byte) string {
+	return base64.StdEncoding.EncodeToString(b)
 }
 
 func (*macaroonSuite) TestVerifySignature(c *gc.C) {
@@ -704,6 +765,15 @@ func (*macaroonSuite) TestJSONDecodeError(c *gc.C) {
 	}
 }
 
+func (*macaroonSuite) TestInvalidMacaroonFields(c *gc.C) {
+	rootKey := []byte("secret")
+	badString := "foo\xff"
+
+	m0 := MustNew(rootKey, []byte("some id"), "a location", macaroon.LatestVersion)
+	err := m0.AddFirstPartyCaveat(badString)
+	c.Assert(err, gc.ErrorMatches, `first party caveat condition is not a valid utf-8 string`)
+}
+
 func decodeB64(s string) []byte {
 	data, err := base64.RawURLEncoding.DecodeString(s)
 	if err != nil {
@@ -795,15 +865,6 @@ func (*macaroonSuite) TestBinaryMarshalingAgainstLibmacaroon(c *gc.C) {
 	err = m1.UnmarshalJSON(jsonData)
 	c.Assert(err, gc.IsNil)
 	assertEqualMacaroons(c, &m0, &m1)
-}
-
-func (*macaroonSuite) TestInvalidMacaroonFields(c *gc.C) {
-	rootKey := []byte("secret")
-	badString := "foo\xff"
-
-	m0 := MustNew(rootKey, []byte("some id"), "a location", macaroon.LatestVersion)
-	err := m0.AddFirstPartyCaveat(badString)
-	c.Assert(err, gc.ErrorMatches, `first party caveat condition is not a valid utf-8 string`)
 }
 
 var binaryFieldBase64ChoiceTests = []struct {

--- a/trace.go
+++ b/trace.go
@@ -1,0 +1,102 @@
+package macaroon
+
+import (
+	"fmt"
+)
+
+// Trace holds all toperations involved in verifying a macaroon,
+// and the root key used as the initial verification key.
+// This can be useful for debugging macaroon implementations.
+type Trace struct {
+	RootKey []byte
+	Ops     []TraceOp
+}
+
+// Results returns the output from all operations in the Trace.
+// The result from ts.Ops[i] will be in the i'th element of the
+// returned slice.
+// When a trace has resulted in a failure, the
+// last element will be nil.
+func (t Trace) Results() [][]byte {
+	r := make([][]byte, len(t.Ops))
+	input := t.RootKey
+	for i, op := range t.Ops {
+		input = op.Result(input)
+		r[i] = input
+	}
+	return r
+}
+
+// TraceOp holds one possible operation when verifying a macaroon.
+type TraceOp struct {
+	Kind  TraceOpKind `json:"kind"`
+	Data1 []byte      `json:"data1,omitempty"`
+	Data2 []byte      `json:"data2,omitempty"`
+}
+
+// Result returns the result of computing the given
+// operation with the given input data.
+// If op is TraceFail, it returns nil.
+func (op TraceOp) Result(input []byte) []byte {
+	switch op.Kind {
+	case TraceMakeKey:
+		return makeKey(input)[:]
+	case TraceHash:
+		if len(op.Data2) == 0 {
+			return keyedHash(bytesToKey(input), op.Data1)[:]
+		}
+		return keyedHash2(bytesToKey(input), op.Data1, op.Data2)[:]
+	case TraceBind:
+		return bindForRequest(op.Data1, bytesToKey(input))[:]
+	case TraceFail:
+		return nil
+	default:
+		panic(fmt.Errorf("unknown trace operation kind %d", op.Kind))
+	}
+}
+
+func bytesToKey(data []byte) *[keyLen]byte {
+	var key [keyLen]byte
+	if len(data) != keyLen {
+		panic(fmt.Errorf("unexpected input key length; got %d want %d", len(data), keyLen))
+	}
+	copy(key[:], data)
+	return &key
+}
+
+// TraceOpKind represents the kind of a macaroon verification operation.
+type TraceOpKind int
+
+const (
+	TraceInvalid = TraceOpKind(iota)
+
+	// TraceMakeKey represents the operation of calculating a
+	// fixed length root key from the variable length input key.
+	TraceMakeKey
+
+	// TraceHash represents a keyed hash operation with one
+	// or two values. If there is only one value, it will be in Data1.
+	TraceHash
+
+	// TraceBind represents the operation of binding a discharge macaroon
+	// to its primary macaroon. Data1 holds the signature of the primary
+	// macaroon.
+	TraceBind
+
+	// TraceFail represents a verification failure. If present, this will always
+	// be the last operation in a trace.
+	TraceFail
+)
+
+var traceOps = []string{
+	TraceInvalid: "invalid",
+	TraceMakeKey: "makekey",
+	TraceHash:    "hash",
+	TraceBind:    "bind",
+	TraceFail:    "fail",
+}
+
+// String returns a string representation of the operation.
+func (k TraceOpKind) String() string {
+	return traceOps[k]
+}


### PR DESCRIPTION
This feature, mainly for debugging, allows a caller to
find out details of the macaroon verification. It
This is intended particularly for debugging divergent
macaroon implementations, but could also be useful
for other uncommon macaroon operations, such
as removing caveats given knowledge of a root key.

	benchmark                    old ns/op     new ns/op     delta
	BenchmarkNew-4               3125          3133          +0.26%
	BenchmarkAddCaveat-4         2831          2804          -0.95%
	BenchmarkVerifyLarge-4       60399         59982         -0.69%
	BenchmarkVerifySmall-4       3925          3914          -0.28%
	BenchmarkMarshalJSON-4       2039          2017          -1.08%
	BenchmarkUnmarshalJSON-4     3863          3843          -0.52%
