### PR TITLE
allow arbitrary binary first party caveats; stable v2

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"gopkg.in/macaroon.v2-unstable"
+	"gopkg.in/macaroon.v2"
 )
 
 func randomBytes(n int) []byte {
@@ -36,7 +36,7 @@ func BenchmarkAddCaveat(b *testing.B) {
 		b.StopTimer()
 		m := MustNew(rootKey, id, loc, macaroon.LatestVersion)
 		b.StartTimer()
-		m.AddFirstPartyCaveat("some caveat stuff")
+		m.AddFirstPartyCaveat([]byte("some caveat stuff"))
 	}
 }
 

--- a/macaroon.go
+++ b/macaroon.go
@@ -165,13 +165,9 @@ func (m *Macaroon) Bind(sig []byte) {
 }
 
 // AddFirstPartyCaveat adds a caveat that will be verified
-// by the target service. The caveat id must be a UTF-8 encoded
-// string.
-func (m *Macaroon) AddFirstPartyCaveat(condition string) error {
-	if !utf8.ValidString(condition) {
-		return fmt.Errorf("first party caveat condition is not a valid utf-8 string")
-	}
-	m.addCaveat([]byte(condition), nil, "")
+// by the target service.
+func (m *Macaroon) AddFirstPartyCaveat(condition []byte) error {
+	m.addCaveat(condition, nil, "")
 	return nil
 }
 

--- a/macaroon_test.go
+++ b/macaroon_test.go
@@ -10,7 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon.v2-unstable"
+	"gopkg.in/macaroon.v2"
 )
 
 func TestPackage(t *testing.T) {
@@ -46,7 +46,7 @@ func (*macaroonSuite) TestFirstPartyCaveat(c *gc.C) {
 	tested := make(map[string]bool)
 
 	for cav := range caveats {
-		m.AddFirstPartyCaveat(cav)
+		m.AddFirstPartyCaveat([]byte(cav))
 	}
 	expectErr := fmt.Errorf("condition not met")
 	check := func(cav string) error {
@@ -61,7 +61,7 @@ func (*macaroonSuite) TestFirstPartyCaveat(c *gc.C) {
 
 	c.Assert(tested, gc.DeepEquals, caveats)
 
-	m.AddFirstPartyCaveat("not met")
+	m.AddFirstPartyCaveat([]byte("not met"))
 	err = m.Verify(rootKey, check, nil)
 	c.Assert(err, gc.Equals, expectErr)
 
@@ -604,7 +604,7 @@ func (s *macaroonSuite) TestMarshalJSON(c *gc.C) {
 func (*macaroonSuite) testMarshalJSONWithVersion(c *gc.C, vers macaroon.Version) {
 	rootKey := []byte("secret")
 	m0 := MustNew(rootKey, []byte("some id"), "a location", vers)
-	m0.AddFirstPartyCaveat("account = 3735928559")
+	m0.AddFirstPartyCaveat([]byte("account = 3735928559"))
 	m0JSON, err := json.Marshal(m0)
 	c.Assert(err, gc.IsNil)
 	var m1 macaroon.Macaroon
@@ -773,13 +773,13 @@ func (*macaroonSuite) TestJSONDecodeError(c *gc.C) {
 	}
 }
 
-func (*macaroonSuite) TestInvalidMacaroonFields(c *gc.C) {
+func (*macaroonSuite) TestFirstPartyCaveatWithInvalidUTF8(c *gc.C) {
 	rootKey := []byte("secret")
 	badString := "foo\xff"
 
 	m0 := MustNew(rootKey, []byte("some id"), "a location", macaroon.LatestVersion)
-	err := m0.AddFirstPartyCaveat(badString)
-	c.Assert(err, gc.ErrorMatches, `first party caveat condition is not a valid utf-8 string`)
+	err := m0.AddFirstPartyCaveat([]byte(badString))
+	c.Assert(err, gc.Equals, nil)
 }
 
 func decodeB64(s string) []byte {
@@ -823,7 +823,7 @@ func makeMacaroon(mspec macaroonSpec) *macaroon.Macaroon {
 				panic(err)
 			}
 		} else {
-			m.AddFirstPartyCaveat(cav.condition)
+			m.AddFirstPartyCaveat([]byte(cav.condition))
 		}
 	}
 	return m
@@ -846,9 +846,9 @@ func (*macaroonSuite) TestBinaryRoundTrip(c *gc.C) {
 	// first and third party caveats.
 	rootKey := []byte("secret")
 	m0 := MustNew(rootKey, []byte("some id"), "a location", macaroon.LatestVersion)
-	err := m0.AddFirstPartyCaveat("first caveat")
+	err := m0.AddFirstPartyCaveat([]byte("first caveat"))
 	c.Assert(err, gc.IsNil)
-	err = m0.AddFirstPartyCaveat("second caveat")
+	err = m0.AddFirstPartyCaveat([]byte("second caveat"))
 	c.Assert(err, gc.IsNil)
 	err = m0.AddThirdPartyCaveat([]byte("shared root key"), []byte("3rd party caveat"), "remote.com")
 	c.Assert(err, gc.IsNil)

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -4,7 +4,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/macaroon.v2-unstable"
+	"gopkg.in/macaroon.v2"
 )
 
 type marshalSuite struct{}
@@ -29,7 +29,7 @@ func (*marshalSuite) testMarshalUnmarshalWithVersion(c *gc.C, vers macaroon.Vers
 	err := m.AddThirdPartyCaveat([]byte("shared root key"), []byte("3rd party caveat"), "remote.com")
 	c.Assert(err, gc.IsNil)
 
-	err = m.AddFirstPartyCaveat("a caveat")
+	err = m.AddFirstPartyCaveat([]byte("a caveat"))
 	c.Assert(err, gc.IsNil)
 
 	b, err := m.MarshalBinary()
@@ -88,9 +88,9 @@ func (*marshalSuite) testMarshalUnmarshalSliceWithVersion(c *gc.C, vers macaroon
 	m1 := MustNew(rootKey, []byte("some id"), "a location", vers)
 	m2 := MustNew(rootKey, []byte("some other id"), "another location", vers)
 
-	err := m1.AddFirstPartyCaveat("a caveat")
+	err := m1.AddFirstPartyCaveat([]byte("a caveat"))
 	c.Assert(err, gc.IsNil)
-	err = m2.AddFirstPartyCaveat("another caveat")
+	err = m2.AddFirstPartyCaveat([]byte("another caveat"))
 	c.Assert(err, gc.IsNil)
 
 	macaroons := macaroon.Slice{m1, m2}
@@ -117,7 +117,7 @@ func (*marshalSuite) testMarshalUnmarshalSliceWithVersion(c *gc.C, vers macaroon
 	// Check that appending a caveat to the first does not
 	// affect the second.
 	for i := 0; i < 10; i++ {
-		err = unmarshaledMacs[0].AddFirstPartyCaveat("caveat")
+		err = unmarshaledMacs[0].AddFirstPartyCaveat([]byte("caveat"))
 		c.Assert(err, gc.IsNil)
 	}
 	unmarshaledMacs[1].SetVersion(macaroons[1].Version())
@@ -138,9 +138,9 @@ func (*marshalSuite) testSliceRoundTripWithVersion(c *gc.C, vers macaroon.Versio
 	m1 := MustNew(rootKey, []byte("some id"), "a location", vers)
 	m2 := MustNew(rootKey, []byte("some other id"), "another location", vers)
 
-	err := m1.AddFirstPartyCaveat("a caveat")
+	err := m1.AddFirstPartyCaveat([]byte("a caveat"))
 	c.Assert(err, gc.IsNil)
-	err = m2.AddFirstPartyCaveat("another caveat")
+	err = m2.AddFirstPartyCaveat([]byte("another caveat"))
 	c.Assert(err, gc.IsNil)
 
 	macaroons := macaroon.Slice{m1, m2}


### PR DESCRIPTION
This fixes issue #16 by making a backwardly incompatible
change to the API.

We choose this moment to commit to a stable
macaroon.v2 API.