### PR TITLE
use quicktest not gocheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+go_import_path: "gopkg.in/macaroon.v2"
+go: 
+  - "1.7"
+  - "1.10"
+before_install:
+  - "go get github.com/rogpeppe/godeps"
+install:
+  - "go get -d gopkg.in/macaroon.v2"
+  - "godeps -u $GOPATH/src/gopkg.in/macaroon.v2/dependencies.tsv"
+script: go test ./...

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -3,34 +3,33 @@ package macaroon
 import (
 	"crypto/rand"
 	"fmt"
+	"testing"
 
+	qt "github.com/frankban/quicktest"
 	"golang.org/x/crypto/nacl/secretbox"
-	gc "gopkg.in/check.v1"
 )
-
-type cryptoSuite struct{}
-
-var _ = gc.Suite(&cryptoSuite{})
 
 var testCryptKey = &[hashLen]byte{'k', 'e', 'y'}
 var testCryptText = &[hashLen]byte{'t', 'e', 'x', 't'}
 
-func (*cryptoSuite) TestEncDec(c *gc.C) {
+func TestEncDec(t *testing.T) {
+	c := qt.New(t)
 	b, err := encrypt(testCryptKey, testCryptText, rand.Reader)
-	c.Assert(err, gc.IsNil)
-	t, err := decrypt(testCryptKey, b)
-	c.Assert(err, gc.IsNil)
-	c.Assert(string(t[:]), gc.Equals, string(testCryptText[:]))
+	c.Assert(err, qt.Equals, nil)
+	p, err := decrypt(testCryptKey, b)
+	c.Assert(err, qt.Equals, nil)
+	c.Assert(string(p[:]), qt.Equals, string(testCryptText[:]))
 }
 
-func (*cryptoSuite) TestUniqueNonces(c *gc.C) {
+func TestUniqueNonces(t *testing.T) {
+	c := qt.New(t)
 	nonces := make(map[string]struct{})
 	for i := 0; i < 100; i++ {
 		nonce, err := newNonce(rand.Reader)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, qt.Equals, nil)
 		nonces[string(nonce[:])] = struct{}{}
 	}
-	c.Assert(nonces, gc.HasLen, 100, gc.Commentf("duplicate nonce detected"))
+	c.Assert(nonces, qt.HasLen, 100, qt.Commentf("duplicate nonce detected"))
 }
 
 type ErrorReader struct{}
@@ -39,22 +38,24 @@ func (*ErrorReader) Read([]byte) (int, error) {
 	return 0, fmt.Errorf("fail")
 }
 
-func (*cryptoSuite) TestBadRandom(c *gc.C) {
+func TestBadRandom(t *testing.T) {
+	c := qt.New(t)
 	_, err := newNonce(&ErrorReader{})
-	c.Assert(err, gc.ErrorMatches, "^cannot generate random bytes:.*")
+	c.Assert(err, qt.ErrorMatches, "^cannot generate random bytes:.*")
 
 	_, err = encrypt(testCryptKey, testCryptText, &ErrorReader{})
-	c.Assert(err, gc.ErrorMatches, "^cannot generate random bytes:.*")
+	c.Assert(err, qt.ErrorMatches, "^cannot generate random bytes:.*")
 }
 
-func (*cryptoSuite) TestBadCiphertext(c *gc.C) {
+func TestBadCiphertext(t *testing.T) {
+	c := qt.New(t)
 	buf := randomBytes(nonceLen + secretbox.Overhead)
 	for i := range buf {
 		_, err := decrypt(testCryptKey, buf[0:i])
-		c.Assert(err, gc.ErrorMatches, "message too short")
+		c.Assert(err, qt.ErrorMatches, "message too short")
 	}
 	_, err := decrypt(testCryptKey, buf)
-	c.Assert(err, gc.ErrorMatches, "decryption failure")
+	c.Assert(err, qt.ErrorMatches, "decryption failure")
 }
 
 func randomBytes(n int) []byte {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,0 +1,5 @@
+github.com/frankban/quicktest	git	2c6a0d60c05cd2d970f356eee0623ddf1cd0d62d	2018-02-06T12:35:47Z
+github.com/google/go-cmp	git	5411ab924f9ffa6566244a9e504bc347edacffd3	2018-03-28T20:15:12Z
+github.com/kr/pretty	git	cfb55aafdaf3ec08f0db22699ab822c50091b1c4	2016-08-23T17:07:15Z
+github.com/kr/text	git	7cafcd837844e784b526369c9bce262804aebc60	2016-05-04T23:40:17Z
+golang.org/x/crypto	git	96846453c37f0876340a66a47f3f75b1f3a6cd2d	2017-04-21T04:31:20Z

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module gopkg.in/macaroon.v2
+
+require (
+	github.com/frankban/quicktest v1.0.0
+	github.com/google/go-cmp v0.2.0
+	golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/frankban/quicktest v0.9.1 h1:YZ/8Avb1F7TnLFdC2I7+azOdsDClm8gWyZFphTCrEas=
+github.com/frankban/quicktest v0.9.1/go.mod h1:kgHnqBPrTT/wmAogMeWyfaDcTJYqWanOYu8sX1UiHLk=
+github.com/frankban/quicktest v1.0.0 h1:QgmxFbprE29UG4oL88tGiiL/7VuiBl5xCcz+wJcJhc0=
+github.com/frankban/quicktest v1.0.0/go.mod h1:R98jIehRai+d1/3Hv2//jOVCTJhW1VBavT6B6CuGq2k=
+github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/kr/pretty v0.0.0-20160823170715-cfb55aafdaf3/go.mod h1:Bvhd+E3laJ0AVkG0c9rmtZcnhV0HQ3+c3YxxqTvc/gA=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.0.0-20160504234017-7cafcd837844/go.mod h1:sjUstKUATFIcff4qlB53Kml0wQPtJVc/3fWrmuUmcfA=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb h1:Ah9YqXLj6fEgeKqcmBuLCbAsrF3ScD7dJ/bYM0C6tXI=
+golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/macaroon.go
+++ b/macaroon.go
@@ -29,7 +29,27 @@ type Macaroon struct {
 	version  Version
 }
 
-// Caveat holds a first person or third party caveat.
+// Equal reports whether m has exactly the same content as m1.
+func (m *Macaroon) Equal(m1 *Macaroon) bool {
+	if m == m1 || m == nil || m1 == nil {
+		return m == m1
+	}
+	if m.location != m1.location ||
+		!bytes.Equal(m.id, m1.id) ||
+		m.sig != m1.sig ||
+		m.version != m1.version ||
+		len(m.caveats) != len(m1.caveats) {
+		return false
+	}
+	for i, c := range m.caveats {
+		if !c.Equal(m1.caveats[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// Caveat holds a first party or third party caveat.
 type Caveat struct {
 	// Id holds the id of the caveat. For first
 	// party caveats this holds the condition;
@@ -46,6 +66,13 @@ type Caveat struct {
 	// as part of the caveat, so should only
 	// be used as a hint.
 	Location string
+}
+
+// Equal reports whether c is equal to c1.
+func (c Caveat) Equal(c1 Caveat) bool {
+	return bytes.Equal(c.Id, c1.Id) &&
+		bytes.Equal(c.VerificationId, c1.VerificationId) &&
+		c.Location == c1.Location
 }
 
 // isThirdParty reports whether the caveat must be satisfied

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1,25 +1,24 @@
 package macaroon_test
 
 import (
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
 
 	"gopkg.in/macaroon.v2"
 )
 
-type marshalSuite struct{}
-
-var _ = gc.Suite(&marshalSuite{})
-
-func (s *marshalSuite) TestMarshalUnmarshalMacaroonV1(c *gc.C) {
-	s.testMarshalUnmarshalWithVersion(c, macaroon.V1)
+func TestMarshalUnmarshalMacaroonV1(t *testing.T) {
+	c := qt.New(t)
+	testMarshalUnmarshalWithVersion(c, macaroon.V1)
 }
 
-func (s *marshalSuite) TestMarshalUnmarshalMacaroonV2(c *gc.C) {
-	s.testMarshalUnmarshalWithVersion(c, macaroon.V2)
+func TestMarshalUnmarshalMacaroonV2(t *testing.T) {
+	c := qt.New(t)
+	testMarshalUnmarshalWithVersion(c, macaroon.V2)
 }
 
-func (*marshalSuite) testMarshalUnmarshalWithVersion(c *gc.C, vers macaroon.Version) {
+func testMarshalUnmarshalWithVersion(c *qt.C, vers macaroon.Version) {
 	rootKey := []byte("secret")
 	m := MustNew(rootKey, []byte("some id"), "a location", vers)
 
@@ -27,28 +26,29 @@ func (*marshalSuite) testMarshalUnmarshalWithVersion(c *gc.C, vers macaroon.Vers
 	// tests a former bug where the caveat wasn't zeroed
 	// before moving to the next caveat.
 	err := m.AddThirdPartyCaveat([]byte("shared root key"), []byte("3rd party caveat"), "remote.com")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, qt.Equals, nil)
 
 	err = m.AddFirstPartyCaveat([]byte("a caveat"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, qt.Equals, nil)
 
 	b, err := m.MarshalBinary()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, qt.Equals, nil)
 
 	var um macaroon.Macaroon
 	err = um.UnmarshalBinary(b)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, qt.Equals, nil)
 
-	c.Assert(um.Location(), gc.Equals, m.Location())
-	c.Assert(string(um.Id()), gc.Equals, string(m.Id()))
-	c.Assert(um.Signature(), jc.DeepEquals, m.Signature())
-	c.Assert(um.Caveats(), jc.DeepEquals, m.Caveats())
-	c.Assert(um.Version(), gc.Equals, vers)
+	c.Assert(um.Location(), qt.Equals, m.Location())
+	c.Assert(string(um.Id()), qt.Equals, string(m.Id()))
+	c.Assert(um.Signature(), qt.DeepEquals, m.Signature())
+	c.Assert(um.Caveats(), qt.DeepEquals, m.Caveats())
+	c.Assert(um.Version(), qt.Equals, vers)
 	um.SetVersion(m.Version())
-	c.Assert(m, jc.DeepEquals, &um)
+	c.Assert(m, qt.DeepEquals, &um)
 }
 
-func (s *marshalSuite) TestMarshalBinaryRoundTrip(c *gc.C) {
+func TestMarshalBinaryRoundTrip(t *testing.T) {
+	c := qt.New(t)
 	// This data holds the V2 binary encoding of
 	data := []byte(
 		"\x02" +
@@ -66,96 +66,100 @@ func (s *marshalSuite) TestMarshalBinaryRoundTrip(c *gc.C) {
 	)
 	var m macaroon.Macaroon
 	err := m.UnmarshalBinary(data)
-	c.Assert(err, gc.Equals, nil)
+	c.Assert(err, qt.Equals, nil)
 	assertLibMacaroonsMacaroon(c, &m)
-	c.Assert(m.Version(), gc.Equals, macaroon.V2)
+	c.Assert(m.Version(), qt.Equals, macaroon.V2)
 
 	data1, err := m.MarshalBinary()
-	c.Assert(err, gc.Equals, nil)
-	c.Assert(data1, jc.DeepEquals, data)
+	c.Assert(err, qt.Equals, nil)
+	c.Assert(data1, qt.DeepEquals, data)
 }
 
-func (s *marshalSuite) TestMarshalUnmarshalSliceV1(c *gc.C) {
-	s.testMarshalUnmarshalSliceWithVersion(c, macaroon.V1)
+func TestMarshalUnmarshalSliceV1(t *testing.T) {
+	c := qt.New(t)
+	testMarshalUnmarshalSliceWithVersion(c, macaroon.V1)
 }
 
-func (s *marshalSuite) TestMarshalUnmarshalSliceV2(c *gc.C) {
-	s.testMarshalUnmarshalSliceWithVersion(c, macaroon.V2)
+func TestMarshalUnmarshalSliceV2(t *testing.T) {
+	c := qt.New(t)
+	testMarshalUnmarshalSliceWithVersion(c, macaroon.V2)
 }
 
-func (*marshalSuite) testMarshalUnmarshalSliceWithVersion(c *gc.C, vers macaroon.Version) {
+func testMarshalUnmarshalSliceWithVersion(c *qt.C, vers macaroon.Version) {
 	rootKey := []byte("secret")
 	m1 := MustNew(rootKey, []byte("some id"), "a location", vers)
 	m2 := MustNew(rootKey, []byte("some other id"), "another location", vers)
 
 	err := m1.AddFirstPartyCaveat([]byte("a caveat"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, qt.Equals, nil)
 	err = m2.AddFirstPartyCaveat([]byte("another caveat"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, qt.Equals, nil)
 
 	macaroons := macaroon.Slice{m1, m2}
 
 	b, err := macaroons.MarshalBinary()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, qt.Equals, nil)
 
 	var unmarshaledMacs macaroon.Slice
 	err = unmarshaledMacs.UnmarshalBinary(b)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, qt.Equals, nil)
 
-	c.Assert(unmarshaledMacs, gc.HasLen, len(macaroons))
+	c.Assert(unmarshaledMacs, qt.HasLen, len(macaroons))
 	for i, m := range macaroons {
 		um := unmarshaledMacs[i]
-		c.Assert(um.Location(), gc.Equals, m.Location())
-		c.Assert(string(um.Id()), gc.Equals, string(m.Id()))
-		c.Assert(um.Signature(), jc.DeepEquals, m.Signature())
-		c.Assert(um.Caveats(), jc.DeepEquals, m.Caveats())
-		c.Assert(um.Version(), gc.Equals, vers)
+		c.Assert(um.Location(), qt.Equals, m.Location())
+		c.Assert(string(um.Id()), qt.Equals, string(m.Id()))
+		c.Assert(um.Signature(), qt.DeepEquals, m.Signature())
+		c.Assert(um.Caveats(), qt.DeepEquals, m.Caveats())
+		c.Assert(um.Version(), qt.Equals, vers)
 		um.SetVersion(m.Version())
 	}
-	c.Assert(macaroons, jc.DeepEquals, unmarshaledMacs)
+	c.Assert(macaroons, qt.DeepEquals, unmarshaledMacs)
 
 	// Check that appending a caveat to the first does not
 	// affect the second.
 	for i := 0; i < 10; i++ {
 		err = unmarshaledMacs[0].AddFirstPartyCaveat([]byte("caveat"))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, qt.Equals, nil)
 	}
 	unmarshaledMacs[1].SetVersion(macaroons[1].Version())
-	c.Assert(unmarshaledMacs[1], jc.DeepEquals, macaroons[1])
-	c.Assert(err, gc.IsNil)
+	c.Assert(unmarshaledMacs[1], qt.DeepEquals, macaroons[1])
+	c.Assert(err, qt.Equals, nil)
 }
 
-func (s *marshalSuite) TestSliceRoundTripV1(c *gc.C) {
-	s.testSliceRoundTripWithVersion(c, macaroon.V1)
+func TestSliceRoundTripV1(t *testing.T) {
+	c := qt.New(t)
+	testSliceRoundTripWithVersion(c, macaroon.V1)
 }
 
-func (s *marshalSuite) TestSliceRoundTripV2(c *gc.C) {
-	s.testSliceRoundTripWithVersion(c, macaroon.V2)
+func TestSliceRoundTripV2(t *testing.T) {
+	c := qt.New(t)
+	testSliceRoundTripWithVersion(c, macaroon.V2)
 }
 
-func (*marshalSuite) testSliceRoundTripWithVersion(c *gc.C, vers macaroon.Version) {
+func testSliceRoundTripWithVersion(c *qt.C, vers macaroon.Version) {
 	rootKey := []byte("secret")
 	m1 := MustNew(rootKey, []byte("some id"), "a location", vers)
 	m2 := MustNew(rootKey, []byte("some other id"), "another location", vers)
 
 	err := m1.AddFirstPartyCaveat([]byte("a caveat"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, qt.Equals, nil)
 	err = m2.AddFirstPartyCaveat([]byte("another caveat"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, qt.Equals, nil)
 
 	macaroons := macaroon.Slice{m1, m2}
 
 	b, err := macaroons.MarshalBinary()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, qt.Equals, nil)
 
 	var unmarshaledMacs macaroon.Slice
 	err = unmarshaledMacs.UnmarshalBinary(b)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, qt.Equals, nil)
 
 	marshaledMacs, err := unmarshaledMacs.MarshalBinary()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, qt.Equals, nil)
 
-	c.Assert(b, jc.DeepEquals, marshaledMacs)
+	c.Assert(b, qt.DeepEquals, marshaledMacs)
 }
 
 var base64DecodeTests = []struct {
@@ -189,15 +193,16 @@ var base64DecodeTests = []struct {
 	expectError: `illegal base64 data at input byte 8`,
 }}
 
-func (*marshalSuite) TestBase64Decode(c *gc.C) {
+func TestBase64Decode(t *testing.T) {
+	c := qt.New(t)
 	for i, test := range base64DecodeTests {
 		c.Logf("test %d: %s", i, test.about)
 		out, err := macaroon.Base64Decode([]byte(test.input))
 		if test.expectError != "" {
-			c.Assert(err, gc.ErrorMatches, test.expectError)
+			c.Assert(err, qt.ErrorMatches, test.expectError)
 		} else {
-			c.Assert(err, gc.Equals, nil)
-			c.Assert(string(out), gc.Equals, test.expect)
+			c.Assert(err, qt.Equals, nil)
+			c.Assert(string(out), qt.Equals, test.expect)
 		}
 	}
 }

--- a/packet-v1_test.go
+++ b/packet-v1_test.go
@@ -3,29 +3,28 @@ package macaroon
 import (
 	"strconv"
 	"strings"
+	"testing"
 	"unicode"
 
-	gc "gopkg.in/check.v1"
+	qt "github.com/frankban/quicktest"
 )
 
-type packetV1Suite struct{}
-
-var _ = gc.Suite(&packetV1Suite{})
-
-func (*packetV1Suite) TestAppendPacket(c *gc.C) {
+func TestAppendPacket(t *testing.T) {
+	c := qt.New(t)
 	data, ok := appendPacketV1(nil, "field", []byte("some data"))
-	c.Assert(ok, gc.Equals, true)
-	c.Assert(string(data), gc.Equals, "0014field some data\n")
+	c.Assert(ok, qt.Equals, true)
+	c.Assert(string(data), qt.Equals, "0014field some data\n")
 
 	data, ok = appendPacketV1(data, "otherfield", []byte("more and more data"))
-	c.Assert(ok, gc.Equals, true)
-	c.Assert(string(data), gc.Equals, "0014field some data\n0022otherfield more and more data\n")
+	c.Assert(ok, qt.Equals, true)
+	c.Assert(string(data), qt.Equals, "0014field some data\n0022otherfield more and more data\n")
 }
 
-func (*packetV1Suite) TestAppendPacketTooBig(c *gc.C) {
+func TestAppendPacketTooBig(t *testing.T) {
+	c := qt.New(t)
 	data, ok := appendPacketV1(nil, "field", make([]byte, 65532))
-	c.Assert(ok, gc.Equals, false)
-	c.Assert(data, gc.IsNil)
+	c.Assert(ok, qt.Equals, false)
+	c.Assert(data, qt.IsNil)
 }
 
 var parsePacketV1Tests = []struct {
@@ -62,17 +61,18 @@ var parsePacketV1Tests = []struct {
 	expectErr: "cannot parse size",
 }}
 
-func (*packetV1Suite) TestParsePacketV1(c *gc.C) {
+func TestParsePacketV1(t *testing.T) {
+	c := qt.New(t)
 	for i, test := range parsePacketV1Tests {
 		c.Logf("test %d: %q", i, truncate(test.data))
 		p, err := parsePacketV1([]byte(test.data))
 		if test.expectErr != "" {
-			c.Assert(err, gc.ErrorMatches, test.expectErr)
-			c.Assert(p, gc.DeepEquals, packetV1{})
+			c.Assert(err, qt.ErrorMatches, test.expectErr)
+			c.Assert(p, packetEquals, packetV1{})
 			continue
 		}
-		c.Assert(err, gc.IsNil)
-		c.Assert(p, gc.DeepEquals, test.expect)
+		c.Assert(err, qt.Equals, nil)
+		c.Assert(p, packetEquals, test.expect)
 	}
 }
 
@@ -83,16 +83,17 @@ func truncate(d string) string {
 	return d
 }
 
-func (*packetV1Suite) TestAsciiHex(c *gc.C) {
+func TestAsciiHex(t *testing.T) {
+	c := qt.New(t)
 	for b := 0; b < 256; b++ {
 		n, err := strconv.ParseInt(string(b), 16, 8)
 		value, ok := asciiHex(byte(b))
 		if err != nil || unicode.IsUpper(rune(b)) {
-			c.Assert(ok, gc.Equals, false)
-			c.Assert(value, gc.Equals, 0)
+			c.Assert(ok, qt.Equals, false)
+			c.Assert(value, qt.Equals, 0)
 		} else {
-			c.Assert(ok, gc.Equals, true)
-			c.Assert(value, gc.Equals, int(n))
+			c.Assert(ok, qt.Equals, true)
+			c.Assert(value, qt.Equals, int(n))
 		}
 	}
 }

--- a/packet-v2_test.go
+++ b/packet-v2_test.go
@@ -1,13 +1,13 @@
 package macaroon
 
 import (
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/google/go-cmp/cmp"
 )
 
-type packetV2Suite struct{}
-
-var _ = gc.Suite(&packetV2Suite{})
+var packetEquals = qt.CmpEquals(cmp.AllowUnexported(packetV1{}, packetV2{}))
 
 var parsePacketV2Tests = []struct {
 	about        string
@@ -54,17 +54,18 @@ var parsePacketV2Tests = []struct {
 	expectError: "varint value extends past end of buffer",
 }}
 
-func (*packetV2Suite) TestParsePacketV2(c *gc.C) {
+func TestParsePacketV2(t *testing.T) {
+	c := qt.New(t)
 	for i, test := range parsePacketV2Tests {
 		c.Logf("test %d: %v", i, test.about)
 		data, p, err := parsePacketV2([]byte(test.data))
 		if test.expectError != "" {
-			c.Assert(err, gc.ErrorMatches, test.expectError)
-			c.Assert(data, gc.IsNil)
-			c.Assert(p, gc.DeepEquals, packetV2{})
+			c.Assert(err, qt.ErrorMatches, test.expectError)
+			c.Assert(data, qt.IsNil)
+			c.Assert(p, packetEquals, packetV2{})
 		} else {
-			c.Assert(err, gc.IsNil)
-			c.Assert(p, jc.DeepEquals, test.expectPacket)
+			c.Assert(err, qt.Equals, nil)
+			c.Assert(p, packetEquals, test.expectPacket)
 		}
 	}
 }
@@ -110,17 +111,18 @@ var parseSectionV2Tests = []struct {
 	expectError: "varint value extends past end of buffer",
 }}
 
-func (*packetV2Suite) TestParseSectionV2(c *gc.C) {
+func TestParseSectionV2(t *testing.T) {
+	c := qt.New(t)
 	for i, test := range parseSectionV2Tests {
 		c.Logf("test %d: %v", i, test.about)
 		data, ps, err := parseSectionV2([]byte(test.data))
 		if test.expectError != "" {
-			c.Assert(err, gc.ErrorMatches, test.expectError)
-			c.Assert(data, gc.IsNil)
-			c.Assert(ps, gc.IsNil)
+			c.Assert(err, qt.ErrorMatches, test.expectError)
+			c.Assert(data, qt.IsNil)
+			c.Assert(ps, qt.IsNil)
 		} else {
-			c.Assert(err, gc.IsNil)
-			c.Assert(ps, jc.DeepEquals, test.expectPackets)
+			c.Assert(err, qt.Equals, nil)
+			c.Assert(ps, packetEquals, test.expectPackets)
 		}
 	}
 }


### PR DESCRIPTION
Quicktest uses less dependencies and is just a thin layer over the
standard testing framework. We add a Macaroon.Equal method to make it
easier to compare macaroons without using unexported fields (this
may be useful externally too).

Also add a go.mod file.