### PR TITLE
ensure vid is always nil

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,9 @@
-github.com/frankban/quicktest v0.9.1 h1:YZ/8Avb1F7TnLFdC2I7+azOdsDClm8gWyZFphTCrEas=
-github.com/frankban/quicktest v0.9.1/go.mod h1:kgHnqBPrTT/wmAogMeWyfaDcTJYqWanOYu8sX1UiHLk=
 github.com/frankban/quicktest v1.0.0 h1:QgmxFbprE29UG4oL88tGiiL/7VuiBl5xCcz+wJcJhc0=
 github.com/frankban/quicktest v1.0.0/go.mod h1:R98jIehRai+d1/3Hv2//jOVCTJhW1VBavT6B6CuGq2k=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/kr/pretty v0.0.0-20160823170715-cfb55aafdaf3/go.mod h1:Bvhd+E3laJ0AVkG0c9rmtZcnhV0HQ3+c3YxxqTvc/gA=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.0.0-20160504234017-7cafcd837844/go.mod h1:sjUstKUATFIcff4qlB53Kml0wQPtJVc/3fWrmuUmcfA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb h1:Ah9YqXLj6fEgeKqcmBuLCbAsrF3ScD7dJ/bYM0C6tXI=

--- a/macaroon.go
+++ b/macaroon.go
@@ -154,6 +154,12 @@ func (m *Macaroon) Caveats() []Caveat {
 
 // appendCaveat appends a caveat without modifying the macaroon's signature.
 func (m *Macaroon) appendCaveat(caveatId, verificationId []byte, loc string) {
+	if len(verificationId) == 0 {
+		// Ensure that an empty vid is always represented by nil,
+		// so that marshalers don't procuce spurious zero-length
+		// vid fields which can confuse some verifiers.
+		verificationId = nil
+	}
 	m.caveats = append(m.caveats, Caveat{
 		Id:             caveatId,
 		VerificationId: verificationId,

--- a/macaroon_test.go
+++ b/macaroon_test.go
@@ -832,7 +832,7 @@ var jsonRoundTripTests = []struct {
 func TestJSONRoundTrip(t *testing.T) {
 	c := qt.New(t)
 	for _, test := range jsonRoundTripTests {
-		c.Run("v%v_%s", func(c *qt.C) {
+		c.Run(fmt.Sprintf("v%v_%s", test.expectVers, test.about), func(c *qt.C) {
 			testJSONRoundTripWithVersion(c, test.data, test.expectVers, test.expectExactRoundTrip)
 		})
 	}


### PR DESCRIPTION
Macaroons using V1 binary format with present-but-empty vids in 3rd party caveats were causing some verifiers to fail, so ensure that we always have a nil vid when a vid is empty to avoid that situation.