### PR TITLE
Fix TestAsciiHex

### DIFF
--- a/packet-v1_test.go
+++ b/packet-v1_test.go
@@ -86,7 +86,7 @@ func truncate(d string) string {
 func TestAsciiHex(t *testing.T) {
 	c := qt.New(t)
 	for b := 0; b < 256; b++ {
-		n, err := strconv.ParseInt(string(b), 16, 8)
+		n, err := strconv.ParseInt(string(byte(b)), 16, 8)
 		value, ok := asciiHex(byte(b))
 		if err != nil || unicode.IsUpper(rune(b)) {
 			c.Assert(ok, qt.Equals, false)


### PR DESCRIPTION
Fixes running tests for Go 1.21. With the current v2 branch, running the tests yields an error message:

```
./packet-v1_test.go:89:30: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
```